### PR TITLE
fix(lint-md-action): use showResult() to output detailed lint errors

### DIFF
--- a/src/lint-md-action.ts
+++ b/src/lint-md-action.ts
@@ -65,7 +65,7 @@ export class LintMdAction {
 
   showResult() {
     if (this.linter) {
-      this.linter.printOverview()
+      this.linter.showResult()
     }
     return this
   }


### PR DESCRIPTION
## 改动

将 `showResult()` 中的 `this.linter.printOverview()` 替换为 `this.linter.showResult()`。

之前只输出一行汇总信息：
```
Lint total 3 files, 0 warnings 1 errors
```

现在输出详细的逐文件逐行错误：
```
/home/user/repo/bad.md
   1:15-1:16             space-round-alphabet          No space between Chinese and alphabet.
   4:1-4:2               no-empty-list                 List content can not be empty.
```

closes #11