### PR TITLE
fix(index): use core.setFailed() to preserve original error message

### DIFF
--- a/src/@lint-md/cli.d.ts
+++ b/src/@lint-md/cli.d.ts
@@ -2,6 +2,7 @@ declare module '@lint-md/cli' {
   export class Lint {
     constructor(files: string[], config: any)
     start(): Promise<void>
+    showResult(): void
     printOverview(): void
     countError(): { error: number; warning: number }
     errorFiles: any[]

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,22 +6,17 @@
  * Email: yuzl1123@163.com
  */
 
+import * as core from '@actions/core'
 import { LintMdAction } from './lint-md-action'
 
 const runAction = async () => {
-  // init LintMdAction
   const lintMdAction = new LintMdAction()
-
-  // run lint
   await lintMdAction.lint()
-
-  // log info
   lintMdAction
     .showResult()
     .showErrorOrPassInfo()
 }
 
-runAction().catch(res => {
-  console.log(res)
-  throw new Error('unknown error!')
+runAction().catch((err: Error) => {
+  core.setFailed(err.message || 'unknown error!')
 })


### PR DESCRIPTION
## 改动

将 `index.ts` 中的错误处理从 `console.log()` + `throw new Error('unknown error!')` 改为 `core.setFailed(err.message)`。

**之前**：原始错误信息丢失，只显示 "unknown error!"
**现在**：保留原始错误信息，正确标记 Action 失败
