### PR TITLE
fix(lint-md-action): unify basePath in getConfig() and add JSON parse error handling

### DIFF
--- a/src/lint-md-action.ts
+++ b/src/lint-md-action.ts
@@ -32,19 +32,22 @@ export class LintMdAction {
   }
 
   getConfig() {
-    // 获取用户传入的配置文件目录
-    const configPath = path.resolve(process.env.GITHUB_WORKSPACE || process.cwd(), core.getInput('configFile'))
+    const configPath = path.resolve(this.basePath, core.getInput('configFile'))
     if (!fs.existsSync(configPath)) {
       core.warning('The user does not have a configuration file to pass in, we will use the default configuration instead...')
       return {}
     }
 
-    // JavaScript 模块，直接 require
     if (configPath.endsWith('.js')) {
       return require(`${configPath}`)
     }
     const content = fs.readFileSync(configPath).toString()
-    return JSON.parse(content)
+    try {
+      return JSON.parse(content)
+    } catch (e) {
+      core.warning(`Failed to parse config file: ${(e as Error).message}`)
+      return {}
+    }
   }
 
   isPass() {


### PR DESCRIPTION
## 改动

1. `getConfig()` 统一使用 `this.basePath`，不再重复 `process.env.GITHUB_WORKSPACE || process.cwd()` 逻辑
2. `JSON.parse` 加 try-catch，无效配置文件时 warning 并返回空配置，不再崩溃
