### PR TITLE
ci(release): create GitHub releases for version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,4 +15,5 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag


### PR DESCRIPTION
## Summary

- create a GitHub Release when a `v*` tag is pushed
- generate release notes from the repository history
- grant only the required `contents: write` permission

## Verification

- `actionlint .github/workflows/release.yml`
- `git diff --check`